### PR TITLE
Add support for Exif:ImageDescription and Exif:UserComment

### DIFF
--- a/plugins/thunar-apr/thunar-apr-image-page.c
+++ b/plugins/thunar-apr/thunar-apr-image-page.c
@@ -56,6 +56,8 @@ static const struct
   { N_ ("Shutter Speed:"),     EXIF_TAG_SHUTTER_SPEED_VALUE, },
   { N_ ("ISO Speed Ratings:"), EXIF_TAG_ISO_SPEED_RATINGS,   },
   { N_ ("Software:"),          EXIF_TAG_SOFTWARE,            },
+  { N_ ("Description:"),       EXIF_TAG_IMAGE_DESCRIPTION,   },
+  { N_ ("Comment:"),           EXIF_TAG_USER_COMMENT,        },
 };
 #endif
 


### PR DESCRIPTION
This time it's all political correct ;-)
Obviously, thunar translators probably need to add support for this two new entires.

IMHO it was better to use libexif versions because this was already translated there and if needed thunar translators could help to improve libexif library.