### PR TITLE
Removed 'the root folder has no parent' dialog box

### DIFF
--- a/thunar/thunar-window.c
+++ b/thunar/thunar-window.c
@@ -3140,7 +3140,11 @@ thunar_window_action_go_up (ThunarWindow *window)
     }
   else
     {
-      thunar_dialogs_show_error (GTK_WIDGET (window), error, _("Failed to open parent folder"));
+      /* the root folder '/' has no parent. In this special case we do not need a dialog */
+      if (error->code != G_FILE_ERROR_NOENT)
+        {
+          thunar_dialogs_show_error (GTK_WIDGET (window), error, _("Failed to open parent folder"));
+        }
       g_error_free (error);
     }
 }


### PR DESCRIPTION
It is a habit of mine and possibly many others to use the keyboard for folder navigation and especially <kbd>Alt</kbd>+<kbd>⇧</kbd>. But then there is this annoying dialog box, which appears when you use these keys to navigate up from <code>/</code>:


Failed to open parent folder.
:---: |
The root folder has no parent.
Close


The dialog box steals the focus, is modal and has to be 'clicked away'. I use the <kbd>Enter</kbd>-key for that, but the travel time for my hand is still disturbing the workflow for the little information this dialog adds, especially considering that the toolbar icon is greyed out and visually communicates the message anyway.